### PR TITLE
移除清單頁的音檔欄位

### DIFF
--- a/語料庫/管理/校對.py
+++ b/語料庫/管理/校對.py
@@ -50,9 +50,8 @@ class 校對表管理(ReadOnlyAdminFields, admin.ModelAdmin):
     list_display = [
         'id', '語者', '狀況',
         '漢字', '本調臺羅', '口語調臺羅',
-        '備註開頭',
+        '對齊狀態', '備註開頭',
         '校對者', '校對時間',
-        '對齊狀態'
     ]
     ordering = ['校對者', 'id', ]
     list_filter = ['語料狀況', '校對者', '音檔', 對齊狀態過濾器]

--- a/語料庫/管理/校對.py
+++ b/語料庫/管理/校對.py
@@ -48,7 +48,7 @@ class 對齊狀態過濾器(admin.SimpleListFilter):
 class 校對表管理(ReadOnlyAdminFields, admin.ModelAdmin):
     # change list
     list_display = [
-        'id', '語者', '音檔', '狀況',
+        'id', '語者', '狀況',
         '漢字', '本調臺羅', '口語調臺羅',
         '備註開頭',
         '校對者', '校對時間',


### PR DESCRIPTION
根據naphing的需求，考慮到校對方便，清單頁版面調整如下
1. 不顯示音檔欄位
2. 對齊狀態移到備註和口語調中間